### PR TITLE
Fix LLM judge status parsing

### DIFF
--- a/evaluator/judge_parser.py
+++ b/evaluator/judge_parser.py
@@ -1,0 +1,18 @@
+import re
+
+
+def parse_judge_response(res_text):
+    thoughts_match = re.search(r"Thoughts:\s*([\s\S]*?)\s*Status\s*:", res_text)
+    status_match = re.search(
+        r'^\s*Status\s*:\s*["\']?(success|failure)["\']?\s*$',
+        res_text,
+        re.IGNORECASE | re.MULTILINE,
+    )
+    thoughts = (
+        thoughts_match.group(1).strip()
+        if thoughts_match
+        else "Thoughts extract failed."
+    )
+    judge = status_match.group(1).lower() if status_match else "unknown"
+    reward = 1 if judge == "success" else 0
+    return {"judge": judge, "thoughts": thoughts, "reward": reward}

--- a/evaluator/llm_as_judge_baseline.py
+++ b/evaluator/llm_as_judge_baseline.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import pathlib
-import re
 from collections import defaultdict
 
 import dotenv
@@ -11,6 +10,7 @@ from tqdm import tqdm
 
 from utils.clogger import _set_logger
 from utils.llm_api import ChatModel
+from evaluator.judge_parser import parse_judge_response
 
 dotenv.load_dotenv()
 _set_logger(
@@ -231,32 +231,14 @@ if __name__ == "__main__":
             )
             res = chat_model.chat_with_retry(message=messages)
             res_text = res.choices[0].message.content
-            judge_pattern = r"Status:\s*([\S]+)"
-            thoughts_pattern=r"Thoughts:([\s\S]+)Status"
-            judge_match = re.search(judge_pattern, res_text, re.DOTALL)
-            thoughts_match = re.search(thoughts_pattern, res_text, re.DOTALL)
-            if judge_match:
-                judge = judge_match.group(1).strip()
-            else:
-                judge = res_text
-            if thoughts_match:
-                thoughts = thoughts_match.group(1).strip()
-            else:
-                thoughts = "Thoughts extract failed."
-            reward = 1
-            if "success" in judge.lower():
-                reward *= 1
-            elif "failure" in judge.lower():
-                reward *= 0
-            else:
-                reward *= 0
+            parsed_judge = parse_judge_response(res_text)
             judge_results.append(
                 {
                     "task_id": task_id,
                     "question": entry["Question"],
-                    "judge": judge,
-                    "judge_reason": thoughts,
-                    "reward": reward,
+                    "judge": parsed_judge["judge"],
+                    "judge_reason": parsed_judge["thoughts"],
+                    "reward": parsed_judge["reward"],
                     "category": entry["category"],
                     "response": response,
                     "messages": entry["messages"],

--- a/tests/test_judge_status_parser.py
+++ b/tests/test_judge_status_parser.py
@@ -1,0 +1,45 @@
+import unittest
+
+from evaluator.judge_parser import parse_judge_response
+
+
+class JudgeStatusParserTest(unittest.TestCase):
+    def test_uses_explicit_failure_status_when_reasoning_mentions_successfully(self):
+        response = (
+            "Thoughts: The agent did not provide the required train departure time "
+            "or ticket price. Because none of the required outputs were produced "
+            "from tool data, the task was not completed successfully.\n"
+            'Status: "failure"'
+        )
+
+        parsed = parse_judge_response(response)
+
+        self.assertEqual(parsed["judge"], "failure")
+        self.assertEqual(parsed["reward"], 0)
+
+    def test_assigns_reward_for_explicit_success_status(self):
+        response = (
+            "Thoughts: The tool calls returned the required data and the final "
+            "answer includes all requested fields.\n"
+            'Status: "success"'
+        )
+
+        parsed = parse_judge_response(response)
+
+        self.assertEqual(parsed["judge"], "success")
+        self.assertEqual(parsed["reward"], 1)
+
+    def test_does_not_score_success_without_explicit_status(self):
+        response = (
+            "Thoughts: The agent says it successfully finished the task, but the "
+            "judge response omitted the required Status line."
+        )
+
+        parsed = parse_judge_response(response)
+
+        self.assertEqual(parsed["judge"], "unknown")
+        self.assertEqual(parsed["reward"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract judge response parsing into a deterministic helper
- score rewards only from an explicit `Status: success|failure` line
- treat missing or malformed status as `unknown` with zero reward instead of searching the full reasoning text
- add parser regression tests for the `not completed successfully` + `Status: "failure"` case

Fixes #9

## Tests
- `python3 -m unittest discover -s tests`
- `python3 -m compileall evaluator tests`
- `git diff --check`