### PR TITLE
fix(copilot): keep stdio startup logs off stdout

### DIFF
--- a/baseline/mcp_copilot/server.py
+++ b/baseline/mcp_copilot/server.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 import asyncio
+import sys
 import mcp.types as types
 from mcp.server.fastmcp import Context, FastMCP
 from baseline.mcp_copilot.router import Router, dump_to_yaml
@@ -15,7 +16,7 @@ def serve(config: dict[str, Any] | Path = Router._default_config_path) -> None:
     Args:
         config: MCP Server config for Router
     """
-    print("Indexing MCP servers and tools...")
+    print("Indexing MCP servers and tools...", file=sys.stderr, flush=True)
     asyncio.run(run_generation())
 
     @asynccontextmanager
@@ -24,7 +25,7 @@ def serve(config: dict[str, Any] | Path = Router._default_config_path) -> None:
         async with Router(config) as router:
             yield {"router": router}
 
-    print("Starting MCP Copilot server...")
+    print("Starting MCP Copilot server...", file=sys.stderr, flush=True)
     server = FastMCP("mcp-copilot", lifespan=copilot_lifespan)
 
     @server.tool(

--- a/tests/test_mcp_copilot_stdio.py
+++ b/tests/test_mcp_copilot_stdio.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import contextlib
+import importlib
+import io
+import sys
+import types
+from pathlib import Path
+
+
+class FakeCallToolResult:
+    pass
+
+
+class FakeContext:
+    pass
+
+
+class FakeRouter:
+    _default_config_path = Path("fake_config.json")
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def route(self, _query):
+        return {}
+
+    async def call_tool(self, *_args, **_kwargs):
+        return FakeCallToolResult()
+
+
+class FakeFastMCP:
+    def __init__(self, *_args, **_kwargs):
+        self.tools = []
+
+    def tool(self, **_kwargs):
+        def decorator(func):
+            self.tools.append(func)
+            return func
+
+        return decorator
+
+    def run(self, *, transport: str) -> None:
+        assert transport == "stdio"
+
+
+async def noop_run_generation() -> None:
+    return None
+
+
+def install_fake_dependencies(monkeypatch):
+    mcp_module = types.ModuleType("mcp")
+    mcp_types_module = types.ModuleType("mcp.types")
+    mcp_types_module.CallToolResult = FakeCallToolResult
+    fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+    fastmcp_module.Context = FakeContext
+    fastmcp_module.FastMCP = FakeFastMCP
+
+    mcp_server_module = types.ModuleType("mcp.server")
+    mcp_server_module.fastmcp = fastmcp_module
+    mcp_module.types = mcp_types_module
+    mcp_module.server = mcp_server_module
+
+    router_module = types.ModuleType("baseline.mcp_copilot.router")
+    router_module.Router = FakeRouter
+    router_module.dump_to_yaml = lambda result: str(result)
+
+    arg_generation_module = types.ModuleType("baseline.mcp_copilot.arg_generation")
+    arg_generation_module.run_generation = noop_run_generation
+
+    monkeypatch.setitem(sys.modules, "mcp", mcp_module)
+    monkeypatch.setitem(sys.modules, "mcp.types", mcp_types_module)
+    monkeypatch.setitem(sys.modules, "mcp.server", mcp_server_module)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_module)
+    monkeypatch.setitem(sys.modules, "baseline.mcp_copilot.router", router_module)
+    monkeypatch.setitem(sys.modules, "baseline.mcp_copilot.arg_generation", arg_generation_module)
+    sys.modules.pop("baseline.mcp_copilot.server", None)
+
+    return importlib.import_module("baseline.mcp_copilot.server")
+
+
+def test_mcp_copilot_stdio_startup_logs_do_not_use_stdout(monkeypatch):
+    server_module = install_fake_dependencies(monkeypatch)
+    monkeypatch.setattr(server_module, "FastMCP", FakeFastMCP)
+    monkeypatch.setattr(server_module, "run_generation", noop_run_generation)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        server_module.serve({})
+
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == (
+        "Indexing MCP servers and tools...\n"
+        "Starting MCP Copilot server...\n"
+    )


### PR DESCRIPTION
## Summary

- Fixes #12.
- Move MCP Copilot startup progress messages from stdout to stderr.
- Add a regression test proving `serve()` does not write startup text to stdout when running the stdio transport.

## Why

MCP stdio reserves stdout for JSON-RPC messages. The Copilot server currently prints:

- `Indexing MCP servers and tools...`
- `Starting MCP Copilot server...`

to stdout before starting `FastMCP(...).run(transport="stdio")`, which can contaminate the JSON-RPC stream and surface as `JSONRPCMessage` validation errors.

This patch keeps the useful progress messages, but sends them to stderr with `flush=True`. It only addresses LiveMCPBench's own Copilot server output; it does not try to sanitize arbitrary third-party MCP servers that may print to stdout.

## Tests

- RED before the fix: `test_mcp_copilot_stdio_startup_logs_do_not_use_stdout` failed because stdout contained both startup lines.
- `PYTHONPATH=/Users/sehlani/.config/superpowers/worktrees/LiveMCPBench/mcp-copilot-stderr uv run --no-project --index-url https://pypi.org/simple --with pytest --python 3.11 python -m pytest /Users/sehlani/.config/superpowers/worktrees/LiveMCPBench/mcp-copilot-stderr/tests/test_mcp_copilot_stdio.py -q`
- `python3 -m py_compile baseline/mcp_copilot/server.py tests/test_mcp_copilot_stdio.py`
- `git diff --check`

Note: I used `--no-project --index-url https://pypi.org/simple` for the focused test because the project's configured package index returned 403 while resolving unrelated project dependencies.