### PR TITLE
fix(copilot): avoid empty embedding inputs during indexing

### DIFF
--- a/baseline/mcp_copilot/arg_generation.py
+++ b/baseline/mcp_copilot/arg_generation.py
@@ -132,6 +132,27 @@ Please return only the generated summary text, without any additional titles or 
                 formatted_params[param_name] = f"({param_type}) {param_desc}"
         return formatted_params
 
+    def _clean_text(self, text: str | None) -> str:
+        return text.strip() if isinstance(text, str) else ""
+
+    def _server_embedding_text(self, server_name: str, server_description: str) -> str:
+        description = self._clean_text(server_description)
+        if description:
+            return description
+        return f"Server: {server_name}"
+
+    def _tool_embedding_text(self, tool: types.Tool) -> str:
+        description = self._clean_text(tool.description)
+        if description:
+            return description
+
+        parts = [f"Tool: {tool.name}"]
+        parameters = self._format_tool_parameters(tool)
+        if parameters:
+            parts.append("Parameters:")
+            parts.extend(f"- {name}: {value}" for name, value in parameters.items())
+        return "\n".join(parts)
+
     async def generate(self) -> None:
         existing_servers_info = []
         existing_server_names = set()
@@ -169,18 +190,26 @@ Please return only the generated summary text, without any additional titles or 
                 types.Tool(**tool)
                 for tool in server["tools"].get(server_name, {}).get("tools", [])
             ]
-            server_description = server["description"]
+            server_description = server.get("description", "")
+            server_description_text = self._server_embedding_text(
+                server_name, server_description
+            )
             logger.info(f"Indexing server: {server_name}")
             try:
                 server_summary = await self._generate_summary(
-                    server_name, server_description, tools
+                    server_name, server_description_text, tools
+                )
+                server_summary_text = (
+                    self._clean_text(server_summary) or server_description_text
                 )
                 embedding_tasks = {
-                    "server_desc": self._get_embedding(server_description),
-                    "server_summary": self._get_embedding(server_summary),
+                    "server_desc": self._get_embedding(server_description_text),
+                    "server_summary": self._get_embedding(server_summary_text),
                 }
                 for i, tool in enumerate(tools):
-                    embedding_tasks[f"tool_{i}"] = self._get_embedding(tool.description)
+                    embedding_tasks[f"tool_{i}"] = self._get_embedding(
+                        self._tool_embedding_text(tool)
+                    )
 
                 embeddings_results = await asyncio.gather(*embedding_tasks.values())
                 embeddings = dict(zip(embedding_tasks.keys(), embeddings_results))

--- a/tests/test_mcp_arg_generation.py
+++ b/tests/test_mcp_arg_generation.py
@@ -1,0 +1,74 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from baseline.mcp_copilot.arg_generation import McpArgGenerator
+
+
+class FakeMcpArgGenerator(McpArgGenerator):
+    def __init__(self, config, output_file):
+        self.config = config
+        self.output_file = Path(output_file)
+        self.embedding_inputs = []
+
+    async def _get_embedding(self, text, model=None):
+        self.embedding_inputs.append(text)
+        return [float(len(self.embedding_inputs))]
+
+    async def _generate_summary(self, server_name, server_desc, tools, model=None):
+        return ""
+
+
+class McpArgGenerationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_generate_uses_non_empty_embedding_text_for_blank_descriptions(self):
+        config = [
+            {
+                "description": "   ",
+                "config": {"mcpServers": {"blank-server": {"command": "echo"}}},
+                "tools": {
+                    "blank-server": {
+                        "tools": [
+                            {
+                                "name": "lookup_user",
+                                "description": "",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "user_id": {
+                                            "type": "string",
+                                            "description": "User identifier",
+                                        }
+                                    },
+                                    "required": ["user_id"],
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        ]
+
+        with TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "mcp_args.json"
+            generator = FakeMcpArgGenerator(config, output_file)
+
+            await generator.generate()
+
+            self.assertNotIn("   ", generator.embedding_inputs)
+            self.assertNotIn("", generator.embedding_inputs)
+            self.assertTrue(
+                any("blank-server" in text for text in generator.embedding_inputs)
+            )
+            self.assertTrue(
+                any("lookup_user" in text for text in generator.embedding_inputs)
+            )
+
+            indexed = json.loads(output_file.read_text(encoding="utf-8"))
+            self.assertEqual(indexed[0]["description_embedding"], [1.0])
+            self.assertEqual(indexed[0]["summary_embedding"], [2.0])
+            self.assertEqual(indexed[0]["tools"][0]["description_embedding"], [3.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Avoid sending blank server descriptions, generated summaries, or tool descriptions to the embedding API during MCP Copilot indexing.
- Build deterministic fallback embedding text from the server name, tool name, and tool parameters when descriptions are missing.
- Add a regression test covering blank server/tool descriptions.

## Why

During `baseline.mcp_copilot.arg_generation`, servers or tools with empty descriptions can currently trigger repeated `Empty text provided for embedding` warnings and produce empty embeddings in the generated tool index. This makes the indexing output less useful and creates confusing logs during benchmark setup.

Related user reports mention this symptom while indexing servers in #8 and #12, though those issues contain additional environment/setup concerns as well.

## Tests

- RED before the fix: `uv run --default-index https://pypi.org/simple --with pytest python -m pytest tests/test_mcp_arg_generation.py -q` failed because embedding inputs included `["   ", "", ""]`.
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/python -m py_compile baseline/mcp_copilot/arg_generation.py tests/test_mcp_arg_generation.py`
- `git diff --check HEAD~1 HEAD`

Note: the repo default uv index currently returned HTTP 403 for `plotly==6.2.0` from the Tsinghua mirror on my machine, so I used the official PyPI index to bootstrap the local verification environment.